### PR TITLE
feat(deps): upgrade postgresql to v16.8; upgrade pvecto.rs to v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ ARG CI_COMMIT_TAG
 ARG CI_UPSTREAM_VERSION
 
 # pgvecto.rs binary container
-FROM tensorchord/pgvecto-rs-binary:pg15-v0.2.1-${TARGETARCH} as binary
+FROM tensorchord/pgvecto-rs-binary:pg16-v0.3.0-${TARGETARCH} as binary
 
 # main container
-FROM ghcr.io/cloudnative-pg/postgresql:15.10-16@sha256:d174f1898e69b8163c4b25f1eabb7583230e762d55b0ad099c53a3895ddf405e
+FROM ghcr.io/cloudnative-pg/postgresql:16.8-14@sha256:ed9bd4a26b152cf35f2c64e15f48126e3477ad222cfb04794562bdc999b8f0be
 
 LABEL org.opencontainers.image.authors="Daniel Muehlbachler-Pietrzykowski <daniel.muehlbachler@niftyside.com>"
 LABEL org.opencontainers.image.vendor="Daniel Muehlbachler-Pietrzykowski"


### PR DESCRIPTION
BREAKING CHANGE: major upgrades for postgresql to v16 and pgvecto.rs to v0.3